### PR TITLE
Fix CEC and CECC examples

### DIFF
--- a/CEC/README.md
+++ b/CEC/README.md
@@ -13,23 +13,31 @@
 3. Navigate to one of the CEC competitions folders, e.g. to `cec2018` by running `cd cec2018`.
 4. Build the library by running `make build`.
 5. Shared library should be installed.
-6. For a simple run, navigate `cd ..` and run `python run_cec.py -c 18`.
+6. For a simple run, navigate `cd ..` and run `python run_cec.py -a BatAlgorithm -c 18 -r log`.
 7. If build has been successful, simple run should output function values and coordinates.
 
 ## Program parameters
 
 Following command line program parameters are applicable for [NiaPy-examples](https://github.com/NiaOrg/NiaPy-examples):
+- `-a` or `--algorithm`: Name of algorithm to use (name of the class of the algorithm in NiaPy).
+- `-n` or  `--population-size`: Number of individuals in population.
+- `--seed`: Set the starting seed of algorithm run. If multiple runs, user can provide list of ints, where each int usd use at new run. Default values is `None`.
 - `-c` or `--cec`: Set the year of CEC competition, options: `8, 13, 14, 15, 17, 18`, e.g. `-c 18`.
 - `-f` or `--fnum`: Set the function number, options: unsigned integers, vary by the benchmark used, e.g. `-f 12`.
 - `-sr` or `--srange`: Set the lower and upper limit of search space for selected function, options: positive and negative real numbers (first number lower than the second).
 - `-d` or `--dimension`: Set the number of dimensions, options: `10, 30, 50, 100`, e.g. `-d 10`.
 - `-nr` or `--nFESreduc`: Set the number of evaluations reduction factor, options: `0.01, 0.02, 0.03, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0`.
-- `-rn` or `--rnum`: Set the number of runs per selected function, options: unsigned integers.
-- `-o` or `--wout`: Set the write generation of data to external file, options: set `True` by options `['true', 'True', 'TRUE', 'T', 'yes', 'Yes', 'YES', 'Y']`, if write generation desired, or set `False` otherwise.
+- `-r` or `--run-type`: Run type of run. If not provided, multiple runs of the algorithm are executed, and the best position and fitness of each run get logged. Value can be:
+  - `log`: Single run. Output is shown every time new global best solution is found
+  - `plot`: Single run. Convergence graph is generated and shown.
+- `-rn` or `--rnum`: Set the number of runs per selected function, only applicable when run type is not provided. Options: positive integers.
+- `-o` or `--wout`: If this flag is set, and no run type is provided, the results of the algorithm runs will be saved to 2 files in the current working directory:
+  - `<algorithm_acronym>_<fnum>_<dimension>_p` - containing the best positions of each run.
+  - `<algorithm_acronym>_<fnum>_<dimension>_v` - containing the best fitness values of each run.
 
 ## Run example
 
-Run command: `python run_cec.py -a 'ASO' -D 10 -f 12 -r log -c 18`
+Run command: `python run_cec.py -a 'AnarchicSocietyOptimization' -D 10 -f 12 -r log -c 18`
 
 Output of run command:
 ```

--- a/CEC/README.md
+++ b/CEC/README.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-- [Python](https://www.python.org/downloads/) >= 3.6 (should also work with version >= 2.7)
+- [Python](https://www.python.org/downloads/) >= 3.6
 - [Cython](https://cython.org/)
 - [NiaPy](https://github.com/NiaOrg/NiaPy)
 

--- a/CEC/cecargparser.py
+++ b/CEC/cecargparser.py
@@ -5,38 +5,21 @@ creduces = [0.01, 0.02, 0.03, 0.05, 0.1, 0.2,
             0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
 
 
-def positiveInt(x):
+def positive_int(x):
     return abs(int(x))
 
 
-def str2bool(x):
-    return True if x in ['true', 'True', 'TRUE', 'T', 'yes', 'Yes', 'YES', 'Y'] else False
-
-
-def MakeArgParserCEC():
+def make_argparser_cec():
     parser = get_argparser()
     parser.add_argument('-c', '--cec', dest='cec',
                         default=ccecs[-1], choices=ccecs, type=int)
     parser.add_argument('-f', '--fnum', dest='fnum',
-                        default=1, type=positiveInt)
+                        default=1, type=positive_int)
     parser.add_argument('-sr', '--srange', dest='srange',
                         nargs=2, default=[-100, 100], type=int)
     parser.add_argument('-nr', '--nFESreduc', dest='reduc',
                         default=creduces[-1], choices=creduces, type=float)
     parser.add_argument('-rn', '--rnum', dest='runs',
-                        default=51, type=positiveInt)
-    parser.add_argument('-o', '--wout', dest='wout',
-                        default=False, type=str2bool)
+                        default=51, type=positive_int)
+    parser.add_argument('-o', '--wout', dest='wout', action='store_true')
     return parser
-
-
-def getArgs(argv):
-    parser = MakeArgParserCEC()
-    args = parser.parse_args(argv)
-    return args
-
-
-def getDictArgs(argv):
-    return vars(getArgs(argv))
-
-# vim: tabstop=3 noexpandtab shiftwidth=3 softtabstop=3

--- a/CEC/cecargparser.py
+++ b/CEC/cecargparser.py
@@ -1,6 +1,6 @@
 from niapy.util.argparser import get_argparser
 
-ccecs = [8, 13, 14, 15, 16, 17, 18]
+ccecs = [8, 13, 14, 15, 16, 17, 18, 19]
 creduces = [0.01, 0.02, 0.03, 0.05, 0.1, 0.2,
             0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
 

--- a/CEC/run_cec.py
+++ b/CEC/run_cec.py
@@ -119,7 +119,8 @@ def run_cec(alg, cec, fnum=1, dimension=10, max_evals=50000, opt_type=Optimizati
 if __name__ == '__main__':
     parser = make_argparser_cec()
     args = parser.parse_args()
-    args['max_evals'] = round(
-        args['dimension'] * get_max_evals(args['cec']) * args['reduc'])
-    algo = get_algorithm(args['algo'], seed=args['seed'][0])
-    run_cec(algo, **args)
+    max_evals = args.dimension * get_max_evals(args.cec) * args.reduc
+    algo = get_algorithm(args.algo, seed=args.seed[0])
+    params = vars(args)
+    params.pop('max_evals')
+    run_cec(algo, max_evals=max_evals, **params)

--- a/CEC/run_cec.py
+++ b/CEC/run_cec.py
@@ -5,7 +5,7 @@ import numpy as np
 from niapy.problems import Problem
 from niapy.task import Task, OptimizationType
 from niapy.util.factory import get_algorithm
-from cecargparser import getDictArgs
+from cecargparser import make_argparser_cec
 
 logging.basicConfig()
 logger = logging.getLogger('cec_run')
@@ -25,76 +25,75 @@ class MinMB(Problem):
         return self.run_fun(x, self.fnum)
 
 
-cdimsOne = [2, 10, 30, 50]
-cdimsTwo = [2, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
-cdimsThree = [10, 30, 50, 100]
-cdimsFour = [10, 30]
+dims_one = [2, 10, 30, 50]
+dims_two = [2, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100]
+dims_three = [10, 30, 50, 100]
+dims_four = [10, 30]
 
 
-def getCecBench(cec, d):
+def get_cec_functions(cec, d):
     if cec == 5:
         sys.path.append('cec2005')
         from cec2005 import run_fun
-        if d not in cdimsOne:
-            raise RuntimeError('Dimension sould be in %s' % (cdimsOne))
+        if d not in dims_one:
+            raise RuntimeError('Dimension should be in %s' % dims_one)
     elif cec == 8:
         sys.path.append('cec2008')
         from cec2008 import run_fun
     elif cec == 13:
         sys.path.append('cec2013')
         from cec2013 import run_fun
-        if d not in cdimsTwo:
-            raise RuntimeError('Dimension sould be in %s' % (cdimsTwo))
+        if d not in dims_two:
+            raise RuntimeError('Dimension should be in %s' % dims_two)
     elif cec == 14:
         sys.path.append('cec2014')
         from cec2014 import run_fun
-        if d not in cdimsThree:
-            raise RuntimeError('Dimension sould be in %s' % (cdimsThree))
+        if d not in dims_three:
+            raise RuntimeError('Dimension should be in %s' % dims_three)
     elif cec == 15:
         sys.path.append('cec2015')
         from cec2015 import run_fun
-        if d not in cdimsFour:
-            raise RuntimeError('Dimension sould be in %s' % (cdimsFour))
+        if d not in dims_four:
+            raise RuntimeError('Dimension should be in %s' % dims_four)
     elif cec == 16:
         sys.path.append('cec2016')
         from cec2016 import run_fun
-        if d not in cdimsOne:
-            raise RuntimeError('Dimension sould be in %s' % (cdimsOne))
+        if d not in dims_one:
+            raise RuntimeError('Dimension should be in %s' % dims_one)
     elif cec == 17:
         sys.path.append('cec2017')
         from cec2017 import run_fun
-        if d not in cdimsThree:
-            raise RuntimeError('Dimension sould be in %s' % (cdimsThree))
+        if d not in dims_three:
+            raise RuntimeError('Dimension should be in %s' % dims_three)
     elif cec == 18:
         sys.path.append('cec2018')
         from cec2018 import run_fun
-        if d not in cdimsThree:
-            raise RuntimeError('Dimension sould be in %s' % (cdimsThree))
+        if d not in dims_three:
+            raise RuntimeError('Dimension should be in %s' % dims_three)
     elif cec == 19:
         sys.path.append('cec2019')
         from cec2019 import run_fun
-        if d not in cdimsThree:
-            raise RuntimeError('Dimension sould be in %s' % (cdimsThree))
+        if d not in dims_three:
+            raise RuntimeError('Dimension should be in %s' % dims_three)
     return run_fun
 
 
-def getMaxFES(cec):
+def get_max_evals(cec):
     if cec == 8:
         return 5000
     else:
         return 10000
 
 
-def run_cec(alg, cec, fnum=1, dimension=10, max_evals=50000, opt_type=OptimizationType.MINIMIZATION, wout=False, sr=(-100, 100), run_type='', runs=10, **kwargs):
-    func = getCecBench(cec, dimension)
+def run_cec(alg, cec, fnum=1, dimension=10, max_evals=50000, opt_type=OptimizationType.MINIMIZATION, wout=False, sr=(-100, 100), run_type='', runs=10, **_kwargs):
+    func = get_cec_functions(cec, dimension)
     problem = MinMB(func, dimension, sr[0], sr[1], fnum)
-    task = Task(problem, optimization_type=opt_type,
-                max_evals=max_evals, enable_logging=run_type == 'log')
 
     if not run_type:
         best_coords = []
         best_fitnesses = []
-        for _ in runs:
+        for _ in range(runs):
+            task = Task(problem, optimization_type=opt_type, max_evals=max_evals)
             best_x, best_fit = alg.run(task)
             logger.info('%s %s' % (best_x, best_fit))
             best_coords.append(best_x)
@@ -105,20 +104,22 @@ def run_cec(alg, cec, fnum=1, dimension=10, max_evals=50000, opt_type=Optimizati
                 alg.Name[1], fnum, dimension), np.asarray(best_coords))
             np.savetxt('{}_{}_{}_v'.format(
                 alg.Name[1], fnum, dimension), np.asarray(best_fitnesses))
-    else:
+    elif run_type == 'log':
+        task = Task(problem, optimization_type=opt_type,
+                    max_evals=max_evals, enable_logging=True)
         best_x, best_fit = alg.run(task)
         logger.info('%s %s' % (best_x, best_fit))
-
-    if run_type == 'plot':
+    else:
+        task = Task(problem, optimization_type=opt_type, max_evals=max_evals)
+        best_x, best_fit = alg.run(task)
+        logger.info('%s %s' % (best_x, best_fit))
         task.plot()
 
 
 if __name__ == '__main__':
-    pargs = getDictArgs(sys.argv[1:])
-    pargs['max_evals'] = round(
-        pargs['dimension'] * getMaxFES(pargs['cec']) * pargs['reduc'])
-    algo = get_algorithm(pargs['algo'], seed=pargs['seed'][0])
-    run_cec(algo, **pargs)
-
-
-# vim: tabstop=3 noexpandtab shiftwidth=3 softtabstop=3
+    parser = make_argparser_cec()
+    args = parser.parse_args()
+    args['max_evals'] = round(
+        args['dimension'] * get_max_evals(args['cec']) * args['reduc'])
+    algo = get_algorithm(args['algo'], seed=args['seed'][0])
+    run_cec(algo, **args)

--- a/CECC/README.md
+++ b/CECC/README.md
@@ -9,26 +9,34 @@
 
 1. Install [NiaPy](https://github.com/NiaOrg/NiaPy).
 2. Clone or download [NiaPy-examples](https://github.com/NiaOrg/NiaPy-examples).
-3. Navigate to one of the CEC competitions folders, e.g. to `cec2014` by running `cd cec2014`.
+3. Navigate to one of the CECC competitions folders, e.g. to `cec2006` by running `cd cec2006`.
 4. Build the library by running `make build`.
 5. Shared library should be installed.
-6. For a simple run, navigate `cd ..` and run `python run_cec.py -c 14`.
+6. For a simple run, navigate `cd ..` and run `python run_cec.py -a BatAlgorithm -c 6 -r log`.
 7. If build has been successful, simple run should output function values and coordinates.
 
 ## Program parameters
 
 Following command line program parameters are applicable for [NiaPy-examples](https://github.com/NiaOrg/NiaPy-examples):
-- `-c` or `--cec`: Set the year of CEC competition, options: `8, 13, 14, 15, 17, 18`, e.g. `-c 14`.
+- `-a` or `--algorithm`: Name of algorithm to use (name of the class of the algorithm in NiaPy).
+- `-n` or  `--population-size`: Number of individuals in population.
+- `--seed`: Set the starting seed of algorithm run. If multiple runs, user can provide list of ints, where each int usd use at new run. Default values is `None`.
+- `-c` or `--cec`: Set the year of CECC competition, options: `6`.
 - `-f` or `--fnum`: Set the function number, options: unsigned integers, vary by the benchmark used, e.g. `-f 12`.
 - `-sr` or `--srange`: Set the lower and upper limit of search space for selected function, options: positive and negative real numbers (first number lower than the second).
 - `-d` or `--dimension`: Set the number of dimensions, options: `10, 30, 50, 100`, e.g. `-d 10`.
 - `-nr` or `--nFESreduc`: Set the number of evaluations reduction factor, options: `0.01, 0.02, 0.03, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0`.
-- `-rn` or `--rnum`: Set the number of runs per selected function, options: unsigned integers.
-- `-o` or `--wout`: Set the write generation of data to external file, options: set `True` by options `['true', 'True', 'TRUE', 'T', 'yes', 'Yes', 'YES', 'Y']`, if write generation desired, or set `False` otherwise.
+- `-r` or `--run-type`: Run type of run. If not provided, multiple runs of the algorithm are executed, and the best position and fitness of each run get logged. Value can be:
+  - `log`: Single run. Output is shown every time new global best solution is found
+  - `plot`: Single run. Convergence graph is generated and shown.
+- `-rn` or `--rnum`: Set the number of runs per selected function, only applicable when run type is not provided. Options: positive integers.
+- `-o` or `--wout`: If this flag is set, and no run type is provided, the results of the algorithm runs will be saved to 2 files in the current working directory:
+  - `<algorithm_acronym>_<fnum>_<dimension>_p` - containing the best positions of each run.
+  - `<algorithm_acronym>_<fnum>_<dimension>_v` - containing the best fitness values of each run.
 
 ## Run example
 
-Run command: `python run_cec.py -a 'ASO' -D 10 -f 12 -r log`
+Run command: `python run_cec.py -a 'AnarchicSocietyOptimization' -D 10 -f 12 -r log`
 
 Output of run command:
 ```

--- a/CECC/README.md
+++ b/CECC/README.md
@@ -2,7 +2,7 @@
 
 ## Requirements
 
-- [Python](https://www.python.org/downloads/) >= 3.6 (should also work with version >= 2.7)
+- [Python](https://www.python.org/downloads/) >= 3.6
 - [NiaPy](https://github.com/NiaOrg/NiaPy)
 
 ## Installation

--- a/CECC/cecargparser.py
+++ b/CECC/cecargparser.py
@@ -5,38 +5,21 @@ creduces = [0.01, 0.02, 0.03, 0.05, 0.1, 0.2,
             0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
 
 
-def positiveInt(x):
+def positive_int(x):
     return abs(int(x))
 
 
-def str2bool(x):
-    return True if x in ['true', 'True', 'TRUE', 'T', 'yes', 'Yes', 'YES', 'Y'] else False
-
-
-def MakeArgParserCEC():
+def make_argparser_cec():
     parser = get_argparser()
     parser.add_argument('-c', '--cec', dest='cec',
                         default=ccecs[-1], choices=ccecs, type=int)
     parser.add_argument('-f', '--fnum', dest='fnum',
-                        default=1, type=positiveInt)
+                        default=1, type=positive_int)
     parser.add_argument('-sr', '--srange', dest='srange',
                         nargs=2, default=[-100, 100], type=int)
     parser.add_argument('-nr', '--nFESreduc', dest='reduc',
                         default=creduces[-1], choices=creduces, type=float)
     parser.add_argument('-rn', '--rnum', dest='runs',
-                        default=51, type=positiveInt)
-    parser.add_argument('-o', '--wout', dest='wout',
-                        default=False, type=str2bool)
+                        default=50, type=positive_int)
+    parser.add_argument('-o', '--wout', dest='wout', action='store_true')
     return parser
-
-
-def getArgs(argv):
-    parser = MakeArgParserCEC()
-    args = parser.parse_args(argv)
-    return args
-
-
-def getDictArgs(argv):
-    return vars(getArgs(argv))
-
-# vim: tabstop=3 noexpandtab shiftwidth=3 softtabstop=3

--- a/CECC/cecargparser.py
+++ b/CECC/cecargparser.py
@@ -1,6 +1,6 @@
 from niapy.util.argparser import get_argparser
 
-ccecs = [8, 13, 14, 15, 16, 17, 18]
+ccecs = [6]
 creduces = [0.01, 0.02, 0.03, 0.05, 0.1, 0.2,
             0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0]
 

--- a/CECC/run_cec.py
+++ b/CECC/run_cec.py
@@ -78,7 +78,8 @@ def run_cec(alg, cec, fnum=1, dimension=10, max_evals=50000, opt_type=Optimizati
 if __name__ == '__main__':
     parser = make_argparser_cec()
     args = parser.parse_args()
-    args['max_evals'] = round(
-        args['dimension'] * get_max_evals(args['cec']) * args['reduc'])
-    algo = get_algorithm(args['algo'], seed=args['seed'][0])
-    run_cec(algo, **args)
+    max_evals = args.dimension * get_max_evals(args.cec) * args.reduc
+    algo = get_algorithm(args.algo, seed=args.seed[0])
+    params = vars(args)
+    params.pop('max_evals')
+    run_cec(algo, max_evals=max_evals, **params)

--- a/CECC/run_cec.py
+++ b/CECC/run_cec.py
@@ -5,7 +5,7 @@ import numpy as np
 from niapy.problems import Problem
 from niapy.task import Task, OptimizationType
 from niapy.util.factory import get_algorithm
-from cecargparser import getDictArgs
+from cecargparser import make_argparser_cec
 
 logging.basicConfig()
 logger = logging.getLogger('cec_run')
@@ -25,35 +25,34 @@ class MinMB(Problem):
         return self.run_fun(x, self.fnum)
 
 
-cdimsOne = [2, 10, 30, 50]
+dims_one = [2, 10, 30, 50]
 
 
-def getCecBench(cec, d):
+def get_cec_functions(cec, d):
     if cec == 6:
         sys.path.append('cec2006')
         from cec2006 import run_fun
-        if d not in cdimsOne:
-            raise RuntimeError('Dimension sould be in %s' % (d))
+        if d not in dims_one:
+            raise RuntimeError('Dimension should be in %s' % d)
     return run_fun
 
 
-def getMaxFES(cec):
+def get_max_evals(cec):
     if cec == 8:
         return 5000
     else:
         return 10000
 
 
-def run_cec(alg, cec, fnum=1, dimension=10, max_evals=50000, opt_type=OptimizationType.MINIMIZATION, wout=False, sr=(-100, 100), run_type='', runs=10, **kwargs):
-    func = getCecBench(cec, dimension)
+def run_cec(alg, cec, fnum=1, dimension=10, max_evals=50000, opt_type=OptimizationType.MINIMIZATION, wout=False, sr=(-100, 100), run_type='', runs=10, **_kwargs):
+    func = get_cec_functions(cec, dimension)
     problem = MinMB(func, dimension, sr[0], sr[1], fnum)
-    task = Task(problem, optimization_type=opt_type,
-                max_evals=max_evals, enable_logging=run_type == 'log')
 
     if not run_type:
         best_coords = []
         best_fitnesses = []
-        for _ in runs:
+        for _ in range(runs):
+            task = Task(problem, optimization_type=opt_type, max_evals=max_evals)
             best_x, best_fit = alg.run(task)
             logger.info('%s %s' % (best_x, best_fit))
             best_coords.append(best_x)
@@ -64,19 +63,22 @@ def run_cec(alg, cec, fnum=1, dimension=10, max_evals=50000, opt_type=Optimizati
                 alg.Name[1], fnum, dimension), np.asarray(best_coords))
             np.savetxt('{}_{}_{}_v'.format(
                 alg.Name[1], fnum, dimension), np.asarray(best_fitnesses))
-    else:
+    elif run_type == 'log':
+        task = Task(problem, optimization_type=opt_type,
+                    max_evals=max_evals, enable_logging=True)
         best_x, best_fit = alg.run(task)
         logger.info('%s %s' % (best_x, best_fit))
-
-    if run_type == 'plot':
+    else:
+        task = Task(problem, optimization_type=opt_type, max_evals=max_evals)
+        best_x, best_fit = alg.run(task)
+        logger.info('%s %s' % (best_x, best_fit))
         task.plot()
 
 
 if __name__ == '__main__':
-    pargs = getDictArgs(sys.argv[1:])
-    pargs['max_evals'] = round(
-        pargs['dimension'] * getMaxFES(pargs['cec']) * pargs['reduc'])
-    algo = get_algorithm(pargs['algo'], seed=pargs['seed'][0])
-    run_cec(algo, **pargs)
-
-# vim: tabstop=3 noexpandtab shiftwidth=3 softtabstop=3
+    parser = make_argparser_cec()
+    args = parser.parse_args()
+    args['max_evals'] = round(
+        args['dimension'] * get_max_evals(args['cec']) * args['reduc'])
+    algo = get_algorithm(args['algo'], seed=args['seed'][0])
+    run_cec(algo, **args)


### PR DESCRIPTION
- Simplified parser code.
- Fixed bugs in the run_cec function.
- Renamed some methods and variables.
- Fixed typos.
- Updated README for both CEC and CECC. Fixes #5 (still missing links to CEC and CECC function definitions)